### PR TITLE
Attempt to port bind before making SSR register

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,10 @@ const store = new MongoDBStore({
   collection: "mySessions",
 });
 
+app.listen(SERVER_PORT, () =>
+    console.log("Server listening on port " + SERVER_PORT)
+);
+
 register(app).then(() => {
   app.use((req, res, next) => {
     res.header("Access-Control-Allow-Origin", "*");
@@ -51,9 +55,7 @@ register(app).then(() => {
   app.use("/", require("./controllers/user"));
   app.use("/", require("./controllers/project"));
   app.use(express.static("public"));
-  app.listen(SERVER_PORT, () =>
-    console.log("Server listening on port " + SERVER_PORT)
-  );
+  
 
   mongoose.set("bufferCommands", false);
   mongoose.connect(


### PR DESCRIPTION
The problem is it seems the SSR stuff takes quite some time.
I'm trying to bind the port before doing SSR stuff.
Another way (and perhaps best) would be to separate the express app (logic) from the HTTP stuff by passing the express app to a raw nodejs server.
Express does start a server for you.
See https://stackoverflow.com/a/38063557/5134605 the second to the last code snippet for what I'm referring to.