### PR TITLE
Throw actual error instances

### DIFF
--- a/server/services/project.js
+++ b/server/services/project.js
@@ -10,7 +10,7 @@ const create = async ({ name, abstract, authors, tags, createdBy }) => {
     const newProject = await project.save();
 
     if (!newProject) {
-      throw "ProjectCreateError";
+      throw new Error("ProjectCreateError");
     }
 
     return [true, project];


### PR DESCRIPTION
Throwing just strings, while it'd "work", it won't give you an error stack which means it'd be pretty useless when debugging